### PR TITLE
Github ActionのCIを追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Next.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ## Memo: 現状stableが12系なので10,14系のテストは不要
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache
+        uses: actions/cache@v2.1.3
+        with:
+          path: ~/.npm
+          key: node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            node-
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run test

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -1,5 +1,5 @@
 import { sum } from "../src/lib/sum";
 
 test("adds 1 + 2 to equal 3", () => {
-  expect(sum(1, 2)).toBe(4);
+  expect(sum(1, 2)).toBe(3);
 });

--- a/test/sum.test.ts
+++ b/test/sum.test.ts
@@ -1,5 +1,5 @@
 import { sum } from "../src/lib/sum";
 
 test("adds 1 + 2 to equal 3", () => {
-  expect(sum(1, 2)).toBe(3);
+  expect(sum(1, 2)).toBe(4);
 });


### PR DESCRIPTION
- ブランチを問わず、pushのタイミングでCIを走らせる
- あまりにCIが走りすぎて許容量を超えるようだったら、PR作成時だけに変更する

## テスト失敗時
![image](https://user-images.githubusercontent.com/40588536/99798221-fcf3c680-2b73-11eb-96a6-7e5b768f7ef7.png)

## 修正後
![image](https://user-images.githubusercontent.com/40588536/99798616-a9ce4380-2b74-11eb-9039-8c4a28e2d7cb.png)
